### PR TITLE
Remove pristine object and properties

### DIFF
--- a/app/src/components/FieldArray.svelte
+++ b/app/src/components/FieldArray.svelte
@@ -10,7 +10,7 @@
 	const {
 		fields,
 		remove,
-		form: { touched, dirty, pristine },
+		form: { touched, dirty },
 	} = useFieldArray<Roles, FormValues>({ name, control });
 </script>
 
@@ -20,6 +20,6 @@
 		<button type="button" on:click={() => remove(index)}>Remove</button>
 		<div>touched: {$touched.roles[index]}</div>
 		<div>dirty: {$dirty.roles[index]}</div>
-		<div>pristine: {$pristine.roles[index]}</div>
+		<div>pristine: {!$dirty.roles[index]}</div>
 	{/each}
 </div>

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -133,7 +133,7 @@
 		isDirty: {$state.isDirty ? 'Yes' : 'No'}
 	</div>
 	<div>
-		isPristine: {$state.isPristine ? 'Yes' : 'No'}
+		isPristine: {!$state.isDirty ? 'Yes' : 'No'}
 	</div>
 	<div>
 		hasErrors: {$state.hasErrors ? 'Yes' : 'No'}

--- a/src/core/useField.ts
+++ b/src/core/useField.ts
@@ -11,7 +11,6 @@ export const useField = <S = unknown, T extends object = object>({
 
 	const touched_store = derived(control.touched, ($touched) => getInternal<boolean>(name, $touched) as boolean);
 	const dirty_store = derived(control.dirty, ($dirty) => getInternal<boolean>(name, $dirty) as boolean);
-	const pristine_store = derived(control.pristine, ($pristine) => getInternal<boolean>(name, $pristine) as boolean);
 	const error_store = derived(
 		control.errors,
 		($errors) => getInternal<string | false>(name, $errors) as string | false,
@@ -35,7 +34,6 @@ export const useField = <S = unknown, T extends object = object>({
 		fieldState: {
 			isTouched: touched_store,
 			isDirty: dirty_store,
-			isPristine: pristine_store,
 			error: error_store,
 		},
 		form: control,

--- a/src/internal/types/Form.ts
+++ b/src/internal/types/Form.ts
@@ -10,7 +10,6 @@ import {
 export type InternalFormState<T extends object> = {
 	values: T;
 	dirty: BooleanFields<T>;
-	pristine: BooleanFields<T>;
 	errors: ErrorFields<T>;
 	touched: BooleanFields<T>;
 	validators: ValidatorFields<T>;

--- a/src/internal/types/UseField.ts
+++ b/src/internal/types/UseField.ts
@@ -16,7 +16,6 @@ export type UseField<S, T extends object> = {
 	fieldState: {
 		isTouched: Readable<boolean>;
 		isDirty: Readable<boolean>;
-		isPristine: Readable<boolean>;
 		error: Readable<string | false>;
 	};
 	form: FormControl<T>;

--- a/src/types/Form.ts
+++ b/src/types/Form.ts
@@ -4,7 +4,6 @@ export type FormState = {
 	isSubmitting: boolean;
 	isValidating: boolean;
 	isTouched: boolean;
-	isPristine: boolean;
 	isDirty: boolean;
 	hasErrors: boolean;
 	submitCount: number;
@@ -76,7 +75,6 @@ export type ResetFieldOptions = {
 	keepDeps?: boolean;
 	keepError?: boolean;
 	keepDirty?: boolean;
-	keepPristine?: boolean;
 	keepDependentErrors?: boolean;
 };
 
@@ -124,7 +122,6 @@ export type Form<T extends object> = {
 	touched: Readable<BooleanFields<T>>;
 	values: Writable<T>;
 	dirty: Readable<BooleanFields<T>>;
-	pristine: Readable<BooleanFields<T>>;
 	validators: Writable<ValidatorFields<T>>;
 	errors: Readable<ErrorFields<T>>;
 	deps: Writable<DependencyFields<T>>;
@@ -146,7 +143,6 @@ export type ReadonlyDeep<T extends object> = {
 export type ValidatorFormState<T extends object> = {
 	values: ReadonlyDeep<T>;
 	dirty: ReadonlyDeep<BooleanFields<T>>;
-	pristine: ReadonlyDeep<BooleanFields<T>>;
 	errors: ReadonlyDeep<ErrorFields<T>>;
 	touched: ReadonlyDeep<BooleanFields<T>>;
 };


### PR DESCRIPTION
Removes pristine object and pristine properties where relevant to reduce JS and improve performance since pristine checks can be made by using the dirty object and the appropriate dirty properties.